### PR TITLE
Fixes to remove warnings when using terraform 0.12

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,27 +2,27 @@
 data "template_file" "setupFortiGate" {
   template = "${file("${path.module}/configscripts/fortigateconfig")}"
   vars = {
-    psk_key     = "${var.psk_key}",
-    remote_subnet = "${var.remote_subnet}"
-    remote_subnet_netmask = "${var.remote_subnet_netmask}"
-    ssl_tunnel_start_ip = "${var.ssl_tunnel_start_ip}"
-    ssl_tunnel_end_ip = "${var.ssl_tunnel_end_ip}"
-    ssl_tunnel_bgp_network_prefix = "${var.ssl_tunnel_bgp_network_prefix}"
+    psk_key                        = "${var.psk_key}",
+    remote_subnet                  = "${var.remote_subnet}"
+    remote_subnet_netmask          = "${var.remote_subnet_netmask}"
+    ssl_tunnel_start_ip            = "${var.ssl_tunnel_start_ip}"
+    ssl_tunnel_end_ip              = "${var.ssl_tunnel_end_ip}"
+    ssl_tunnel_bgp_network_prefix  = "${var.ssl_tunnel_bgp_network_prefix}"
     ssl_tunnel_bgp_network_netmask = "${var.ssl_tunnel_bgp_network_netmask}"
-    set_bgp_remote_as = "${var.set_bgp_remote_as}"
-    hub_tunnel_ip = "${var.hub_tunnel_ip}"
-    hub_tunnel_netmask = "${var.hub_tunnel_netmask}"
-    spoke_tunnel_ip = "${var.spoke_tunnel_ip}"
+    set_bgp_remote_as              = "${var.set_bgp_remote_as}"
+    hub_tunnel_ip                  = "${var.hub_tunnel_ip}"
+    hub_tunnel_netmask             = "${var.hub_tunnel_netmask}"
+    spoke_tunnel_ip                = "${var.spoke_tunnel_ip}"
   }
 }
 
 data "template_file" "easy_key_setup" {
   template = "${file("${path.module}/configscripts/easy_key_setup")}"
   vars = {
-    hubGatewayIp     = "${azurerm_public_ip.public_ip.ip_address}",
-    hub_tunnel_ip = "${var.hub_tunnel_ip}"
+    hubGatewayIp   = "${azurerm_public_ip.public_ip.ip_address}",
+    hub_tunnel_ip  = "${var.hub_tunnel_ip}"
     hubIndentifier = "${var.set_bgp_remote_as}"
-    indentifier = "${var.set_bgp_remote_as}"
-    tunnelIp = "${var.spoke_tunnel_ip}"
-    }
+    indentifier    = "${var.set_bgp_remote_as}"
+    tunnelIp       = "${var.spoke_tunnel_ip}"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 # Configure the Azure Provider
 # Values can be found by az login / az account get-access-token
 provider "azurerm" {
-  version = "=1.44.0"
-  //  client_id       = "${var.client_id}"
-  //  subscription_id = "${var.subscription_id}"
-  //  tenant_id       = "${var.tenant_id}"
+  version         = "=1.44.0"
+  client_id       = "${var.client_id}"
+  subscription_id = "${var.subscription_id}"
+  tenant_id       = "${var.tenant_id}"
 }
 
 #Random 5 char string appended to the end of each name to avoid conflicts

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,9 @@
 # Values can be found by az login / az account get-access-token
 provider "azurerm" {
   version = "=1.44.0"
-  client_id = "${var.client_id}"
-  subscription_id = "${var.subscription_id}"
-  tenant_id = "${var.tenant_id}"
+  //  client_id       = "${var.client_id}"
+  //  subscription_id = "${var.subscription_id}"
+  //  tenant_id       = "${var.tenant_id}"
 }
 
 #Random 5 char string appended to the end of each name to avoid conflicts
@@ -16,93 +16,93 @@ resource "random_string" "random_name_post" {
 }
 resource "azurerm_resource_group" "resource_group" {
   name     = "${var.cluster_name}-rsg-${random_string.random_name_post.result}"
-  location = "${var.region}"
+  location = var.region
 }
 # Create a virtual network within the resource group
 resource "azurerm_virtual_network" "external_network" {
   name                = "${var.cluster_name}-vpc-${random_string.random_name_post.result}"
-  resource_group_name = "${azurerm_resource_group.resource_group.name}"
-  location            = "${azurerm_resource_group.resource_group.location}"
+  resource_group_name = azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.resource_group.location
   address_space       = ["10.0.0.0/16"]
 }
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.resource_group.name}"
-  virtual_network_name = "${azurerm_virtual_network.external_network.name}"
+  resource_group_name  = azurerm_resource_group.resource_group.name
+  virtual_network_name = azurerm_virtual_network.external_network.name
   address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_network_interface" "main" {
   name                = "${var.cluster_name}-nic-${random_string.random_name_post.result}"
-  location            = "${azurerm_resource_group.resource_group.location}"
-  resource_group_name = "${azurerm_resource_group.resource_group.name}"
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
 
 
   ip_configuration {
     name                          = "${var.cluster_name}-IP-${random_string.random_name_post.result}"
-    subnet_id                     = "${azurerm_subnet.internal.id}"
+    subnet_id                     = azurerm_subnet.internal.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id  = "${azurerm_public_ip.public_ip.id}"
+    public_ip_address_id          = azurerm_public_ip.public_ip.id
   }
 }
 
 resource "azurerm_virtual_machine" "main" {
-  name                  = "${var.cluster_name}-vm-${random_string.random_name_post.result}"
-  location              = "${azurerm_resource_group.resource_group.location}"
-  resource_group_name   = "${azurerm_resource_group.resource_group.name}"
-  network_interface_ids = ["${azurerm_network_interface.main.id}"]
-  vm_size               = "Standard_DS1_v2"
+  name                          = "${var.cluster_name}-vm-${random_string.random_name_post.result}"
+  location                      = azurerm_resource_group.resource_group.location
+  resource_group_name           = azurerm_resource_group.resource_group.name
+  network_interface_ids         = ["${azurerm_network_interface.main.id}"]
+  vm_size                       = "Standard_DS1_v2"
   delete_os_disk_on_termination = true
   plan {
-    name = "fortinet_fg-vm_payg_20190624"
+    name      = "fortinet_fg-vm_payg_20190624"
     publisher = "fortinet"
-    product = "fortinet_fortigate-vm_v5"
+    product   = "fortinet_fortigate-vm_v5"
   }
 
   storage_image_reference {
     publisher = "fortinet"
     offer     = "fortinet_fortigate-vm_v5"
-    sku       =  "fortinet_fg-vm_payg_20190624"
+    sku       = "fortinet_fg-vm_payg_20190624"
     version   = "6.2.3"
   }
-    storage_os_disk {
+  storage_os_disk {
     name              = "osdisk1"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"
   }
-    os_profile {
+  os_profile {
     computer_name  = "FortiGateSecureAccess"
-    admin_username = "${var.admin_name}"
-    admin_password =  "${var.admin_password}"
-    custom_data  = "${data.template_file.setupFortiGate.rendered}"
+    admin_username = var.admin_name
+    admin_password = var.admin_password
+    custom_data    = data.template_file.setupFortiGate.rendered
   }
-    os_profile_linux_config {
+  os_profile_linux_config {
     disable_password_authentication = false
   }
 
 }
 resource "azurerm_public_ip" "public_ip" {
   name                = "PublicIPForFortiGate"
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.resource_group.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.resource_group.name
   allocation_method   = "Static"
 }
 
 output "ResourceGroup" {
-  value = "${azurerm_resource_group.resource_group.id}"
+  value = azurerm_resource_group.resource_group.id
 }
 output "PublicIP" {
-  value = "${azurerm_public_ip.public_ip.ip_address}"
+  value = azurerm_public_ip.public_ip.ip_address
 }
 output "AdminPassword" {
-  value ="${var.admin_password}"
+  value = var.admin_password
 }
 output "AdminName" {
-  value ="${var.admin_name}"
+  value = var.admin_name
 }
 
 output "EasyKey" {
-  value = base64encode("${data.template_file.easy_key_setup.rendered}")
+  value       = base64encode("${data.template_file.easy_key_setup.rendered}")
   description = "Use this key to in the Spoke setup to generate the VPN config."
 }

--- a/vars.tf
+++ b/vars.tf
@@ -15,69 +15,69 @@ variable "region" {
   default = "West US"
 }
 variable "cluster_name" {
-  type    = "string"
+  type    = string
   default = "fortigate-secure-remote-access"
 }
 variable "admin_name" {
-  type    = "string"
+  type    = string
   default = "masteradmin"
 }
 variable "admin_password" {
-  type    = "string"
+  type    = string
   default = "Temp1234!"
 }
 variable "psk_key" {
-  type    = "string"
+  type    = string
   default = "123456789"
 }
 # Subnet of the office or home network spoke
 variable "remote_subnet" {
-  type    = "string"
+  type    = string
   default = "10.100.81.0"
 }
 variable "remote_subnet_netmask" {
-  type    = "string"
-  default = "255.255.255.0"
+  type    = string
+  default = "255.55.255.0"
 }
 # Start and End IP of the tunnel. This will determine how many users can connect.
 variable "ssl_tunnel_start_ip" {
-  type    = "string"
+  type    = string
   default = "10.212.134.200"
 }
 variable "ssl_tunnel_end_ip" {
-  type    = "string"
+  type    = string
   default = "10.212.134.210"
 }
 variable "set_bgp_remote_as" {
-  type = "string"
+  type    = string
   default = "65400"
 }
 # Set the BGP route for the tunnel network.
 variable "ssl_tunnel_bgp_network_prefix" {
-  type    = "string"
+  type    = string
   default = "10.212.134.0"
 }
 variable "ssl_tunnel_bgp_network_netmask" {
-  type    = "string"
+  type    = string
   default = "255.255.255.0"
 }
 
 #Hub Tunnel Interface IP
 variable "hub_tunnel_ip" {
-  type = "string"
+  type    = string
   default = "10.10.1.1"
 }
 variable "hub_tunnel_netmask" {
-  type = "string"
+  type    = string
   default = "255.255.255.255"
 }
 
 #Spoke tunnel IP
 variable "spoke_tunnel_ip" {
-  type = "string"
+  type    = string
   default = "10.10.1.3"
 }
 variable "spoke_tunnel_netmask" {
-  type = "string"
+  type    = string
   default = "255.255.255.0"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -37,7 +37,7 @@ variable "remote_subnet" {
 }
 variable "remote_subnet_netmask" {
   type    = string
-  default = "255.55.255.0"
+  default = "255.255.255.0"
 }
 # Start and End IP of the tunnel. This will determine how many users can connect.
 variable "ssl_tunnel_start_ip" {


### PR DESCRIPTION
When the code is executed using terraform 0.12, several warnings appears related to the definition of variables, I fixed that along with the execution of terraform fmt, to fixe indentation based on the canonical format and style.